### PR TITLE
Added packer config to generate ACM Labs VM

### DIFF
--- a/packer/.gitignore
+++ b/packer/.gitignore
@@ -1,0 +1,2 @@
+packer_cache/
+output-ubuntu-16/

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,12 @@
+# Packer VirtualBox OVF Generator for ACM Labs
+The files in this directory specify the steps needed to create a
+virtual machine with Bro, MongoDB, RITA, Wireshark, and the ACM labs.
+
+# Packer
+[Packer](https://www.packer.io/) is a tool for provisioning virtual machines. Packer can be installed by following the instructions at https://www.packer.io/intro/getting-started/install.html#precompiled-binaries.
+
+## Building the Ubuntu 16.04 Lab VM
+Once Packer is installed, simply run `packer build ubuntu-16.json`. The resulting vm will be located in `./output-ubuntu-16`.
+The username and password for the generated vm are `ubuntu`.
+The ACM labs can be found on the desktop and do not require internet access.
+The virtual machine requires 4 GB of RAM and 2 CPU cores. These requirements are driven by Wireshark.

--- a/packer/http/preseed.cfg
+++ b/packer/http/preseed.cfg
@@ -1,0 +1,52 @@
+# Ubuntu preseed file - preseed.cfg
+# Works for Ubuntu 10.x, 11.x & 12.x
+#
+# For more information on preseed syntax and commands, refer to:
+# https://help.ubuntu.com/12.04/installation-guide/i386/appendix-preseed.html
+#
+# For testing, you can fire up a local http server temporary.
+# Download the preseed.cfg file locally, cd to the directory where the
+# preseed.cfg resides and run hte following command:
+#  $ python -m SimpleHTTPServer
+# You don't have to restart the server every time you make changes.  Python
+# will reload the file from disk every time there is a request.  As long as you
+# save your changes they will be reflected in the next HTTP download.  Then to
+# test with a PXE boot server, use the following kernel boot parameters:
+#  > linux auto url=http://<your_ip>:8000/preseed.cfg hostname=<hostname> locale=en_US keyboard-configuration/modelcode=SKIP
+#
+# NOTE: If you netboot/PXE boot Ubuntu, it will ignore the value in hostname,
+# but you must provide a hostname as a boot parameter to prevent the Ubuntu
+# install from prompting for a hostname
+
+choose-mirror-bin mirror/http/proxy string
+#d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+
+#adding ubuntu-desktop to the next line doesn't seem to work...
+tasksel tasksel/first multiselect standard, openssh-server
+d-i pkgsel/include string ntp curl
+d-i pkgsel/install-language-support boolean false
+# Policy for applying updates.  May be "none" (no automatic updates),
+# "unattended-upgrades" (install security updates automatically), or
+# "landscape" (manage system with Landscape).
+d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/upgrade select none
+d-i time/zone string UTC
+

--- a/packer/ubuntu-16.json
+++ b/packer/ubuntu-16.json
@@ -1,0 +1,74 @@
+{
+	"builders": [{
+		"type": "virtualbox-iso",
+		"guest_os_type": "Ubuntu_64",
+		"boot_command": [
+			"<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+			"/install/vmlinuz noapic ",
+			"file=/floppy/preseed.cfg ",
+			"debian-installer=en_US.UTF-8 auto locale=en_US.UTF-8 kbd-chooser/method=us ",
+			"hostname=ACMLabs ",
+			"grub-installer/bootdev=/dev/sda<wait> ",
+			"fb=false debconf/frontend=noninteractive ",
+			"keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+			"keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+			"passwd/user-fullname=ACM User ",
+			"passwd/user-password=ubuntu ",
+			"passwd/user-password-again=ubuntu ",
+			"passwd/username=ubuntu ",
+			"initrd=/install/initrd.gz -- <enter>"
+	    	],
+		"floppy_files": [
+			"http/preseed.cfg"
+		],
+		"iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso",
+		"iso_checksum": "16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
+		"iso_checksum_type": "sha256",
+		"output_directory": "output-ubuntu-16",
+		"vm_name": "activecm-labs-ubuntu-16.04-amd64",
+		"hard_drive_interface": "sata",
+		"disk_size": 20000,
+		"headless": "false",
+		"http_directory": "http",
+		"boot_wait": "5s",
+		"ssh_timeout": "60m",
+		"ssh_username": "ubuntu",
+		"ssh_password": "ubuntu",
+		"shutdown_command": "echo 'ubuntu' | sudo -S systemctl poweroff",
+		"vboxmanage": [
+			["modifyvm", "{{.Name}}", "--memory", 4096],
+			["modifyvm", "{{.Name}}", "--cpus", 2],
+			["modifyvm", "{{.Name}}", "--graphicscontroller", "vboxsvga"],
+			["modifyvm", "{{.Name}}", "--vram", 128],
+			["modifyvm", "{{.Name}}", "--accelerate3d", "on"]
+		]
+	}],
+	"provisioners": [
+		{
+			"type": "shell",
+			"inline": [
+				"wget --directory-prefix=/home/ubuntu/Downloads/ http://download.opensuse.org/repositories/network:bro/xUbuntu_16.04/Release.key",
+				"echo 'ubuntu' | sudo -S /bin/bash -c 'apt-key add - < /home/ubuntu/Downloads/Release.key'",
+				"echo 'ubuntu' | sudo -S /bin/bash -c 'echo deb http://download.opensuse.org/repositories/network:/bro/xUbuntu_16.04/ /> /etc/apt/sources.list.d/Bro.list'",
+				"echo 'ubuntu' | sudo -S apt-get update",
+				"echo 'ubuntu' | sudo -S DEBIAN_FRONTEND=noninteractive apt-get -y install xubuntu-desktop virtualbox-guest-dkms tshark wireshark bro broctl",
+				"echo 'ubuntu' | sudo -S wget --directory-prefix=/opt/bro/share/bro/site/ja3/ 'https://raw.githubusercontent.com/salesforce/ja3/master/bro/__load__.bro'",
+				"echo 'ubuntu' | sudo -S wget --directory-prefix=/opt/bro/share/bro/site/ja3/ 'https://raw.githubusercontent.com/salesforce/ja3/master/bro/intel_ja3.bro'",
+				"echo 'ubuntu' | sudo -S wget --directory-prefix=/opt/bro/share/bro/site/ja3/ 'https://raw.githubusercontent.com/salesforce/ja3/master/bro/ja3.bro'",
+				"echo 'ubuntu' | sudo -S wget --directory-prefix=/opt/bro/share/bro/site/ja3/ 'https://raw.githubusercontent.com/salesforce/ja3/master/bro/ja3s.bro'",
+				"echo 'ubuntu' | sudo -S /bin/bash -c 'echo @load ./ja3 >> /opt/bro/share/bro/site/local.bro'",
+				"echo 'ubuntu' | sudo -S /bin/bash -c 'echo redef Site::local_nets += { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 }\\; >> /opt/bro/share/bro/site/local.bro'",
+				"echo 'ubuntu' | sudo -S ln -s /opt/bro/bin/bro /usr/local/bin/zeek",
+				"echo 'ubuntu' | sudo -S ln -s /opt/bro/bin/bro /usr/local/bin/bro",
+				"wget --directory-prefix=/home/ubuntu/Downloads https://github.com/activecm/rita/releases/download/v3.1.1/install.sh",
+				"chmod +x /home/ubuntu/Downloads/install.sh",
+				"echo 'ubuntu' | sudo -S DEBIAN_FRONTEND=noninteractive /home/ubuntu/Downloads/install.sh --disable-bro",
+				"echo 'ubuntu' | sudo -S sed -i.orig 's|^    #InternalSubnets:$|    InternalSubnets: [ 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 ]|' /etc/rita/config.yaml",
+				"wget --mirror --convert-links --adjust-extension --page-requisites --no-parent --directory-prefix=/home/ubuntu/Desktop/ https://activecm.github.io/threat-hunting-labs",
+				"wget --directory-prefix=/home/ubuntu/Desktop/ https://github.com/activecm/threat-hunting-labs/releases/download/v1.0/sample-1500.pcap",
+				"wget --directory-prefix=/home/ubuntu/Desktop/ https://github.com/activecm/threat-hunting-labs/releases/download/v1.0/sample-500.pcap",
+				"wget --directory-prefix=/home/ubuntu/Desktop/ https://github.com/activecm/threat-hunting-labs/releases/download/v1.0/sample-200.pcap"
+			]
+		}
+	]
+}

--- a/packer/ubuntu-16.json
+++ b/packer/ubuntu-16.json
@@ -60,7 +60,7 @@
 				"echo 'ubuntu' | sudo -S /bin/bash -c 'echo redef Site::local_nets += { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 }\\; >> /opt/bro/share/bro/site/local.bro'",
 				"echo 'ubuntu' | sudo -S ln -s /opt/bro/bin/bro /usr/local/bin/zeek",
 				"echo 'ubuntu' | sudo -S ln -s /opt/bro/bin/bro /usr/local/bin/bro",
-				"wget --directory-prefix=/home/ubuntu/Downloads https://github.com/activecm/rita/releases/download/v3.1.1/install.sh",
+				"wget --directory-prefix=/home/ubuntu/Downloads https://github.com/activecm/rita/releases/latest/download/install.sh",
 				"chmod +x /home/ubuntu/Downloads/install.sh",
 				"echo 'ubuntu' | sudo -S DEBIAN_FRONTEND=noninteractive /home/ubuntu/Downloads/install.sh --disable-bro",
 				"echo 'ubuntu' | sudo -S sed -i.orig 's|^    #InternalSubnets:$|    InternalSubnets: [ 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 ]|' /etc/rita/config.yaml",


### PR DESCRIPTION
These files create a VM containing the threat hunting labs and the programs needed to carry them out. 

I had to install bro manually inside the vm since the rita installer doesn't support unattended installations of bro. Wireshark takes up a dumb amount of RAM, so I went with XFCE to keep the requirements low. As it stands, the VM will function with 4 GB of RAM. But, if the user wants to run RITA and Wireshark at the same time, I'd recommend bumping the allocated RAM up.

There's a bug where the vm won't resize the display unless its ran the first time and then rebooted. I can't figure out how to fix it though.

The link to the VM in vmdk+ovf format is https://drive.google.com/open?id=1anuTvNPatxmiivxky1k_TegYTGoOXeE1 